### PR TITLE
Brief outline of changes to ice dance player

### DIFF
--- a/intent_schema.json
+++ b/intent_schema.json
@@ -31,6 +31,15 @@
       "intent": "RunThroughProgramIntent"
     },
     {
+      "slots": [
+        {
+          "name": "dance",
+          "type": "DANCE"
+        }
+      ],
+      "intent": "PlayDanceIntent"
+    },
+    {
       "intent": "AMAZON.PauseIntent"
     },
     {

--- a/skatinghelper.py
+++ b/skatinghelper.py
@@ -69,6 +69,9 @@ SKATER_DATA = {
     }
 }
 
+dance_levels = ["Preliminary", "Pre-Bronze", "Bronze", "Pre-Silver", "Silver", 
+                "Pre-Gold", "Gold", "International"]
+
 ########################
 ### Play Music Logic ###
 ########################
@@ -96,6 +99,14 @@ def play_program(skater, variant, element, delay):
         return response_play_music("shawn_pan_free.mp3", offset=44000, message="playing from your step sequence")
 
     return response_play_music(program["music"], delay=delay)
+
+def play_dance(dance):
+    if dance in dance_levels:
+        break
+        # play entire level playlist, in some order?
+    else:
+        break
+        # check some mapping of dance names/abbreviations to pronunciations?
 
 #################
 ### Responses ###
@@ -193,6 +204,9 @@ def lambda_handler(event, context):
             skater = intent.get("slots", {}).get("skater", {}).get("value", "").lower()
             variant = intent.get("slots", {}).get("variant", {}).get("value", "").lower()
             return play_program(skater, variant, "", True)
+        elif intent_name == "PlayDanceIntent":
+            dance = intent.get("slots", {}).get("dance", {}).get("value", "").lower()
+            return play_dance(dance)
         elif intent_name == "AMAZON.CancelIntent" or intent_name == "AMAZON.StopIntent" or intent_name == "AMAZON.PauseIntent":
             return response_stop_music() # TODO persist track info and location on pause
         elif intent_name == "AMAZON.ResumeIntent":
@@ -238,3 +252,5 @@ def soundex(word):
         result += current
         last = current
   return result
+
+

--- a/utterances.txt
+++ b/utterances.txt
@@ -24,3 +24,9 @@ PlayProgramIntent play program for {skater} from the {element}
 PlayProgramIntent play {variant} for {skater} from the {element}
 PlayProgramIntent play {variant} program for {skater} from the {element}
 PlayProgramIntent play music for {skater} from the {element}
+PlayDanceIntent play dance {dance}
+PlayDanceIntent play dance music {dance}
+PlayDanceIntent play ice dance {dance}
+PlayDanceIntent play ice dance music {dance}
+PlayDanceIntent play {dance} ice dances
+PlayDanceIntent play {dance} playlist


### PR DESCRIPTION
I wanted to make sure that I was on the right track with both the implementation and also the intended UI for this change. The two usages that I imagined were:

- User can say "Play gold level dances" - Alexa plays the playlist of gold dances
- User can say "Play Dutch Waltz" - In this case, I'm not sure if we want to play Dutch Waltz 1, or play all of the 5 in some order, or prompt the user to pick one? I personally don't play ice dance music very much so I'm not sure.

Then about the implementations:
- I'm not sure how the files are named, and how to match them to pronunciations. It seems that a lot of the dances should be recognizable as some mashup of English words, and wouldn't need special matchings. For the ones that are, if we specify a dance slot, will that be sufficient for Alexa to match the dances?
- I'm also not sure about any short names that are used for dances and what people would expect to hear if they said something like "play tango".